### PR TITLE
follow official env settings for config dir codex and claude

### DIFF
--- a/src/skm/types.py
+++ b/src/skm/types.py
@@ -111,7 +111,7 @@ def _get_known_agents() -> dict[str, str]:
     for agent, env_var in _AGENT_ENV_OVERRIDES.items():
         val = os.environ.get(env_var)
         if val:
-            result[agent] = str(Path(val) / 'skills')
+            result[agent] = str(Path(val).expanduser() / 'skills')
     return result
 
 


### PR DESCRIPTION
`skm` currently hardcodes built-in agent skill directories, for example:
  
- `claude` -> `~/.claude/skills`
- `codex` -> `~/.codex/skills`

but the follow environment variable will change the above behavior like following:

- If `CLAUDE_CONFIG_DIR` is set, use `$CLAUDE_CONFIG_DIR/skills` for `claude`
- If `CODEX_HOME` is set, use `$CODEX_HOME/skills` for `codex`

and this PR read the above envs, and follow the skills sub folder as expected.
---
FYI: 
- https://code.claude.com/docs/en/settings
- no direct proof, but it works https://developers.openai.com/codex/config-reference/